### PR TITLE
Rename curriculum, add conversation summary, and update README links

### DIFF
--- a/CONVERSATION_SUMMARY.md
+++ b/CONVERSATION_SUMMARY.md
@@ -1,0 +1,56 @@
+# BJJ Black Belt Curriculum Project — Conversation Summary (through Jan 19, 2026)
+
+## Conversation 1 — BJJ Journal (3 Stripes)
+
+### Intent
+You want to paste your coach’s post-class notes into the project after each class, then discuss and convert them into drills, cues, and next-session goals.
+
+### Coach notes: Jan 15, 2026 (REVIVAL — Thursday, 10am Adult JiuJitsu)
+**Theme:** Escaping turtle position
+- Concepts
+- Mechanics
+- Movements
+- Transitions
+- Interplay between positions
+- Building height
+- Quadding up
+
+### Coach notes: Jan 19, 2026 (REVIVAL — Monday, 12pm Adult Gi JiuJitsu Grappling)
+**Theme:** Back escapes
+- Concepts emphasized:
+  - Wedges
+  - Placeholders
+  - Connections
+  - Angles
+- Sequencing goal:
+  - Into irimi ashi garami
+  - To hip-heist up
+  - To pass of choice (example: tornado pass)
+- Phase 2 problem set:
+  - Dealing with chokes
+  - Dealing with partner going to mount
+  - Dealing with partner resetting controls
+
+### Reflections from Jan 19 positional rounds
+- You hit a Santa Claus choke on a blue belt who tends to go harder than necessary, even during learning-focused rounds.
+- You also helped coach a white belt who was not understanding the mechanics. You applied only enough pressure for them to practice, and you stayed focused on positional offense rather than hunting submissions.
+
+---
+
+## Conversation 2 — Strategy for Tall / Lanky Athletes
+
+### Context
+You have been studying Emily Kwok’s approach to handling bigger, stronger opponents. You noted her framing is from the perspective of a shorter athlete.
+
+### Question
+You are tall, lanky, and (when in shape) fairly thin. You want guidance on how to adapt the "bigger/stronger opponent" strategies to your build (long limbs and different leverage).
+
+---
+
+## Conversation 3 — Black Belt Timeline + Posture Alignment
+
+### Question
+You asked for a realistic estimate of how long it could take you to reach black belt given your current training frequency and progress.
+
+### Follow-up need
+You requested additional drills specifically to reinforce posture alignment.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ Related notes are automatically linked when they share:
 - The same category
 - Common tags
 
+## Integrated BJJ + Judo Curriculum
+
+See [integrated_bjj_judo_black_belt_curriculum.md](integrated_bjj_judo_black_belt_curriculum.md) for the integrated BJJ + Judo black belt curriculum overview.
+
+## Conversation Summary
+
+See [CONVERSATION_SUMMARY.md](CONVERSATION_SUMMARY.md) for the latest high-level notes about coaching themes, strategy questions, and training reflections captured for this project.
+
 ## Future Enhancements
 
 Potential features to add:

--- a/integrated_bjj_judo_black_belt_curriculum.md
+++ b/integrated_bjj_judo_black_belt_curriculum.md
@@ -1,0 +1,150 @@
+# Integrated BJJ + Judo Black Belt Curriculum
+
+*A unified, long-arc grappling education from white belt to black belt*
+
+---
+
+## Philosophy
+
+This curriculum treats Brazilian Jiu-Jitsu and Judo as **one integrated grappling system** expressed under different rule sets. Rank is awarded based on **demonstrated competence, integration, and teaching ability**, not time served.
+
+The end goal is a practitioner who:
+- Dictates where the fight takes place (standing or ground)
+- Understands why techniques work
+- Transitions seamlessly between phases
+- Can teach and preserve the art
+
+---
+
+## White Belt Phase (Years 0–1)
+
+**Identity:** Student of Balance and Pressure
+
+### Stand-Up (Judo emphasis ~60%)
+- Ukemi (breakfalls) in all directions
+- Posture, stance, and movement
+- Basic gripping (sleeve, lapel, collar)
+- Kuzushi concepts without full throws
+- Clinch comfort and safety
+
+### Ground (BJJ emphasis ~40%)
+- Escapes: mount, side control, back
+- Framing and hip movement
+- Guard awareness (closed and open concepts)
+- Fundamental pins and positional hierarchy
+
+### Integration Benchmarks
+- Falls safely under resistance
+- Enters clinch without panic
+- Understands top vs bottom hierarchy
+- Can disengage or commit intentionally
+
+---
+
+## Blue Belt Phase (Years 1–3)
+
+**Identity:** Position Chooser
+
+### Stand-Up (~50%)
+- Two preferred throws (one forward, one backward)
+- Grip fighting with intent
+- Failed throw → ground transition
+- Basic throw-to-pin sequences
+
+### Ground (~50%)
+- One primary guard
+- One guard pass system
+- Submission chains from top
+- Stand-up initiation from guard
+
+### Integration Benchmarks
+- Strategic choice between throwing and pulling guard
+- Throws land into dominant positions
+- Clear understanding of rule differences
+- All ground exchanges initiated intentionally
+
+---
+
+## Purple Belt Phase (Years 3–6)
+
+**Identity:** Tactical Grappler
+
+### Stand-Up (~45%)
+- Advanced grip sequences
+- Feints and false attacks
+- Throw chains and combinations
+- Defense against high-level throwers
+- Tactical understanding of scoring vs submission
+
+### Ground (~55%)
+- Advanced guard retention
+- Submission traps during scrambles
+- Passing through movement, not force
+- Pin maintenance under pressure
+
+### Integration Benchmarks
+- Throws create disadvantage, not scrambles
+- Can modulate pace against different athletes
+- Knows when to stall vs flow
+- Can verbally explain positional decisions
+
+---
+
+## Brown Belt Phase (Years 6–9)
+
+**Identity:** Strategist and Mentor
+
+### Stand-Up (~40%)
+- Grip denial mastery
+- Tempo manipulation
+- Energy-efficient throwing
+- Defensive posture that invites errors
+- Seamless rule-set adaptation
+
+### Ground (~60%)
+- Near-impregnable defense
+- Submissions finished with inevitability
+- Control without exhaustion
+- Teaching stand-to-ground transitions
+
+### Integration Benchmarks
+- Rarely taken down cleanly
+- Rarely swept cleanly
+- Controls pacing of rounds
+- Coaches others during live training
+- No separation between “judo mode” and “BJJ mode”
+
+---
+
+## Black Belt Phase (9+ Years)
+
+**Identity:** Complete Grappler
+
+### Technical Expression
+- Effortless stand-up
+- Inescapable ground control
+- Throws land directly into dominance
+- Submissions emerge naturally
+
+### Teaching & Legacy
+- Translates judo concepts to BJJ students
+- Translates BJJ ground concepts to judoka
+- Preserves safety, culture, and standards
+- Develops systems, not just techniques
+
+### Mental State
+- Calm under chaos
+- Ego-free execution
+- Curiosity-driven growth
+- Adaptable across generations
+
+---
+
+## Summary Definition
+
+A black belt produced by this curriculum:
+- Chooses where the fight happens
+- Understands why positions work
+- Uses balance before strength
+- Treats standing and ground as one exchange
+- Can compete, teach, and evolve indefinitely


### PR DESCRIPTION
### Motivation
- Use the requested, explicit filename for the integrated curriculum so it’s easier to reference (`integrated_bjj_judo_black_belt_curriculum.md`).
- Capture recent coaching themes, training reflections, and strategy questions in a dedicated summary to make notes discoverable and reusable (`CONVERSATION_SUMMARY.md`).
- Surface both documents from the project landing page so contributors and users can find the curriculum and conversation notes quickly by linking them from `README.md`.

### Description
- Renamed the existing curriculum file to `integrated_bjj_judo_black_belt_curriculum.md` and preserved the full curriculum content. 
- Added a new `CONVERSATION_SUMMARY.md` containing coach notes, session themes, questions about tall/lanky athlete strategy, and black-belt timeline/posture follow-ups. 
- Updated `README.md` to link to `integrated_bjj_judo_black_belt_curriculum.md` and `CONVERSATION_SUMMARY.md` for discoverability. 
- Changes are documentation-only and limited to adding and relinking files.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea667d994832c8381eb2b31e775ed)